### PR TITLE
Strip mention and trim to prevent white space when using Teams

### DIFF
--- a/CSharp/BotAuth/Dialogs/AuthDialog.cs
+++ b/CSharp/BotAuth/Dialogs/AuthDialog.cs
@@ -77,10 +77,7 @@ namespace BotAuth.Dialogs
                         else
                         {
                             // handle at mentions in Teams
-                            var text = msg.Text;
-                            if (text.Contains("</at>"))
-                                text = text.Substring(text.IndexOf("</at>") + 5).Trim();
-
+                            var text = msg.RemoveRecipientMention().Trim();
                             if (text.Length >= 6 && magicNumber.ToString() == text.Substring(0, 6))
                             {
                                 context.UserData.SetValue<string>($"{this.authProvider.Name}{ContextConstants.MagicNumberValidated}", "true");


### PR DESCRIPTION
If message text is stripped of mentions during your bot's MessageController - this can leave leading whitespace in the message text - causing the original code to only contain part of the magic number, which in turn causes authentication to fail.

Therefore, always remove mention text and trim leading and trailing whitespace.