### PR TITLE
Use IBotDataStore<BotData> for state in CallbackController

### DIFF
--- a/CSharp/BotAuth/Controllers/CallbackController.cs
+++ b/CSharp/BotAuth/Controllers/CallbackController.cs
@@ -56,9 +56,17 @@ namespace BotAuth.Controllers
                 using (var scope = DialogModule.BeginLifetimeScope(Conversation.Container, message))
                 {
                     // Get the UserData from the original conversation
-                    IStateClient sc = scope.Resolve<IStateClient>();
-                    BotData userData = await sc.BotState.GetUserDataAsync(message.ChannelId, message.From.Id);
-
+                    IBotDataStore<BotData> stateStore = scope.Resolve<IBotDataStore<BotData>>();
+                    var key = new AddressKey()
+                    {
+                        BotId = message.Recipient.Id,
+                        ChannelId = message.ChannelId,
+                        UserId = message.From.Id,
+                        ConversationId = message.Conversation.Id,
+                        ServiceUrl = message.ServiceUrl
+                    };
+                    var userData = await stateStore.LoadAsync(key, BotStoreType.BotUserData, CancellationToken.None);
+                    
                     // Get Access Token using authorization code
                     var authOptions = userData.GetProperty<AuthenticationOptions>($"{authProvider.Name}{ContextConstants.AuthOptions}");
                     var token = await authProvider.GetTokenByAuthCodeAsync(authOptions, code);
@@ -77,10 +85,13 @@ namespace BotAuth.Controllers
                                 userData.SetProperty($"{authProvider.Name}{ContextConstants.MagicNumberKey}", magicNumber);
                                 userData.SetProperty($"{authProvider.Name}{ContextConstants.MagicNumberValidated}", "false");
                             }
-                            sc.BotState.SetUserData(message.ChannelId, message.From.Id, userData);
+                            
+                            await stateStore.SaveAsync(key, BotStoreType.BotUserData, userData, CancellationToken.None);
+                            await stateStore.FlushAsync(key, CancellationToken.None);
+
                             writeSuccessful = true;
                         }
-                        catch (HttpOperationException)
+                        catch (Exception)
                         {
                             writeSuccessful = false;
                         }
@@ -105,6 +116,15 @@ namespace BotAuth.Controllers
                 // Callback is called with no pending message as a result the login flow cannot be resumed.
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, ex);
             }
+        }
+
+        private class AddressKey : IAddress
+        {
+            public string BotId { get; set; }
+            public string ChannelId { get; set; }
+            public string ConversationId { get; set; }
+            public string ServiceUrl { get; set; }
+            public string UserId { get; set; }
         }
 
         private int GenerateRandomNumber()


### PR DESCRIPTION
This will ensure that bots with a custom state client implementation are able to use this library.  

**scope.Resolve<IStateClient>();** will resolve to the default state client, and is being deprecated.  

**scope.Resolve<IBotDataStore<BotData>>();** resolves to the same implementation as the context state methods.